### PR TITLE
Fix invalid icon links in head config

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -32,10 +32,10 @@ export default {
       { rel: 'apple-touch-icon', sizes: '144x144', href: '/apple-icon-144x144.png' },
       { rel: 'apple-touch-icon', sizes: '152x152', href: '/apple-icon-152x152.png' },
       { rel: 'apple-touch-icon', sizes: '180x180', href: '/apple-icon-180x180.png' },
-      { rel: 'icon" type="image/png', sizes: '192x192', href: '/android-icon-192x192.png' },
-      { rel: 'icon" type="image/png', sizes: '32x32', href: '/favicon-32x32.png' },
-      { rel: 'icon" type="image/png', sizes: '96x96', href: '/favicon-96x96.png' },
-      { rel: 'icon" type="image/png', sizes: '16x16', href: '/favicon-16x16.png' },
+      { rel: 'icon', type: 'image/png', sizes: '192x192', href: '/android-icon-192x192.png' },
+      { rel: 'icon', type: 'image/png', sizes: '32x32', href: '/favicon-32x32.png' },
+      { rel: 'icon', type: 'image/png', sizes: '96x96', href: '/favicon-96x96.png' },
+      { rel: 'icon', type: 'image/png', sizes: '16x16', href: '/favicon-16x16.png' },
       { rel: 'manifest', href: '/manifest.json' },
       // Included by Vuetify automatically
       // {


### PR DESCRIPTION
## Summary
- fix incorrect `rel` attributes for icon links in `nuxt.config.js`

## Testing
- `npm run lint` *(fails: Invalid option '--ignore-path')*

------
https://chatgpt.com/codex/tasks/task_e_68464d618dc4832e8e6c361772ac9a69